### PR TITLE
Use c_encoding function for datatype conversion

### DIFF
--- a/libcron/src/CronSchedule.cpp
+++ b/libcron/src/CronSchedule.cpp
@@ -46,7 +46,7 @@ namespace libcron
                 //Add days until the current weekday is one of the allowed weekdays
                 year_month_weekday ymw = date::floor<days>(curr);
 
-                if (data.get_day_of_week().find(static_cast<DayOfWeek>(unsigned(ymw.weekday()))) ==
+                if (data.get_day_of_week().find(static_cast<DayOfWeek>(ymw.weekday().c_encoding())) ==
                     data.get_day_of_week().end())
                 {
                     sys_days s = ymd;


### PR DESCRIPTION
The MSVC compiler does not accept direct conversion from weekday datatype (used in the date.h dependency) to unsigned int used in the DayOfWeek Enum. However, the c_encoding function gives the necessary datatype conversion.