### PR TITLE
Adding remove-feature to Cron-Class

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,14 +42,14 @@ When Calling `libcron::Cron::tick` from another thread than `add_schedule`, `cle
 
 ```
 /* The default class uses NullLock, which does not lock the resources at runtime */
-template<typename ClockType = libcron::LocalClock, typename TaskLockType = libcron::TaskLockerNone>
+template<typename ClockType = libcron::LocalClock, typename LockType = libcron::NullLock>
 class Cron
 {
 	...
 }
 
-/* To define an alias for a thread-safe Cron scheduler automatically locking ressources when needed */ 
-using CronMt = libcron::Cron<libcron::LocalClock, libcron::TaskLocker>
+/* Define an alias for a thread-safe Cron scheduler which automatically locks ressources when needed */ 
+using CronMt = libcron::Cron<libcron::LocalClock, libcron::Locker>
 
 CronMt cron;
 cron.add_schedule("Hello from Cron", "* * * * * ?", [=]() {
@@ -59,7 +59,7 @@ cron.add_schedule("Hello from Cron", "* * * * * ?", [=]() {
 ....
 ```
 
-However, this comes with costs: Whenever you call `tick`, a `std::mutex` will be locked and unlocked.  So only use the `TaskLocker` to protect resources when you really need too.
+However, this comes with costs: Whenever you call `tick`, a `std::mutex` will be locked and unlocked.  So only use the `libcron::Locker` to protect resources when you really need too.
 
 ## Local time vs UTC
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ For example, `cron.remove_schedule("Hello from Cron")` will remove the previousl
 When Calling `libcron::Cron::tick` from another thread than `add_schedule`, `clear_schedule` and `remove_schedule`, one must take care to protect the internal resources of `libcron::Cron` so that tasks are not removed or added while `libcron::Cron` is iterating over the schedules. `libcron::Cron` can take care of that, you simply have to define your own aliases:
 
 ```
-/* The defaut class uses TaskLockerNone, which does no lock the ressources at runtime */
+/* The default class uses NullLock, which does not lock the resources at runtime */
 template<typename ClockType = libcron::LocalClock, typename TaskLockType = libcron::TaskLockerNone>
 class Cron
 {
@@ -147,4 +147,3 @@ when using randomization, i.e. mutual exclusiveness and no extra spaces.
 # Used Third party libraries
 
 Howard Hinnant's [date libraries](https://github.com/HowardHinnant/date/)
-

--- a/libcron/include/libcron/Cron.h
+++ b/libcron/include/libcron/Cron.h
@@ -148,7 +148,7 @@ namespace libcron
     }
     
     template<typename ClockType>
-    void Cron<ClockType>::remove_schedule(std::string name)
+    void Cron<ClockType>::remove_schedule(const std::string& name)
     {
         tasks.remove(name);
     }

--- a/libcron/include/libcron/Cron.h
+++ b/libcron/include/libcron/Cron.h
@@ -91,11 +91,8 @@ namespace libcron
                         lock.lock();
 
                         /* Copy current elements */
-                        std::vector<Task> temp = c;
-
-                        /* Clear the Container */
-                        while (!empty())
-                            pop();
+                        std::vector<Task> temp{};
+                        std::swap(temp, c);
 
                         /* Refill with elements ensuring correct order by calling push */
                         for (const auto& task : temp)

--- a/libcron/include/libcron/Cron.h
+++ b/libcron/include/libcron/Cron.h
@@ -22,7 +22,7 @@ namespace libcron
         public:
 
             bool add_schedule(std::string name, const std::string& schedule, std::function<void()> work);
-            void remove_schedules();
+            void clear_schedules();
             void remove_schedule(std::string name);
 
             size_t count() const

--- a/libcron/include/libcron/Cron.h
+++ b/libcron/include/libcron/Cron.h
@@ -10,14 +10,14 @@
 
 namespace libcron
 {
-    class TaskLockerNone 
+    class NullLock 
     {
         public:
             void lock() {}
             void unlock() {}
     };
 
-    class TaskLocker
+    class Locker
     {
         public:
             TaskLocker() : lck(m, std::defer_lock) {}
@@ -31,7 +31,7 @@ namespace libcron
     template<typename ClockType, typename TaskLockType>
     class Cron;
 
-    template<typename ClockType, typename TaskLockType>
+    template<typename ClockType, typename LockType>
     std::ostream& operator<<(std::ostream& stream, const Cron<ClockType, TaskLockType>& c);
 
     template<typename ClockType = libcron::LocalClock, typename TaskLockType = libcron::TaskLockerNone>

--- a/libcron/include/libcron/Task.h
+++ b/libcron/include/libcron/Task.h
@@ -68,7 +68,7 @@ inline bool operator==(const libcron::Task &lhs, const std::string &rhs)
 
 inline bool operator!=(const std::string &lhs, const libcron::Task &rhs)
 {
-    return lhs != rhs.get_name();
+    return !(lhs == rhs);
 }
 
 inline bool operator!=(const libcron::Task &lhs, const std::string &rhs)

--- a/libcron/include/libcron/Task.h
+++ b/libcron/include/libcron/Task.h
@@ -55,3 +55,23 @@ namespace libcron
             std::chrono::system_clock::time_point last_run = std::numeric_limits<std::chrono::system_clock::time_point>::min();
     };
 }
+
+inline bool operator==(const std::string &lhs, const libcron::Task &rhs)
+{
+    return lhs == rhs.get_name();
+}
+
+inline bool operator==(const libcron::Task &lhs, const std::string &rhs)
+{
+    return lhs.get_name() == rhs;
+}
+
+inline bool operator!=(const std::string &lhs, const libcron::Task &rhs)
+{
+    return lhs != rhs.get_name();
+}
+
+inline bool operator!=(const libcron::Task &lhs, const std::string &rhs)
+{
+    return lhs.get_name() != rhs;
+}

--- a/libcron/include/libcron/Task.h
+++ b/libcron/include/libcron/Task.h
@@ -73,5 +73,5 @@ inline bool operator!=(const std::string &lhs, const libcron::Task &rhs)
 
 inline bool operator!=(const libcron::Task &lhs, const std::string &rhs)
 {
-    return lhs.get_name() != rhs;
+    return !(lhs == rhs);
 }

--- a/test/CronTest.cpp
+++ b/test/CronTest.cpp
@@ -386,7 +386,7 @@ SCENARIO("Tasks can be added and removed from the scheduler")
             }
             AND_THEN("Removing all scheduled tasks")
             {
-                c.remove_schedules();
+                c.clear_schedules();
                 REQUIRE(c.count() == 0);
             }
             AND_THEN("Removing a task that does not exist")

--- a/test/CronTest.cpp
+++ b/test/CronTest.cpp
@@ -335,3 +335,70 @@ SCENARIO("Multiple ticks per second")
     }
 
 }
+
+SCENARIO("Tasks can be added and removed from the scheduler")
+{
+    GIVEN("A Cron instance with no task")
+    {
+        Cron<> c;
+        auto expired = false;
+
+        WHEN("Adding 5 tasks that runs every second")
+        {
+            REQUIRE(c.add_schedule("Task-1", "* * * * * ?",
+                                   [&expired]()
+                                   {
+                                       expired = true;
+                                   })
+            );
+
+            REQUIRE(c.add_schedule("Task-2", "* * * * * ?",
+                                   [&expired]()
+                                   {
+                                       expired = true;
+                                   })
+            );
+
+            REQUIRE(c.add_schedule("Task-3", "* * * * * ?",
+                                   [&expired]()
+                                   {
+                                       expired = true;
+                                   })
+            );
+
+            REQUIRE(c.add_schedule("Task-4", "* * * * * ?",
+                                   [&expired]()
+                                   {
+                                       expired = true;
+                                   })
+            );
+
+            REQUIRE(c.add_schedule("Task-5", "* * * * * ?",
+                                   [&expired]()
+                                   {
+                                       expired = true;
+                                   })
+            );
+
+            THEN("Count is 5")
+            {
+                REQUIRE(c.count() == 5);
+            }
+            AND_THEN("Removing all scheduled tasks")
+            {
+                c.remove_schedules();
+                REQUIRE(c.count() == 0);
+            }
+            AND_THEN("Removing a task that does not exist")
+            {
+                c.remove_schedule("Task-6");
+                REQUIRE(c.count() == 5);
+            }
+            AND_THEN("Removing a task that does exist")
+            {
+                c.remove_schedule("Task-5");
+                REQUIRE(c.count() == 4);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adding functions to remove a specific schedule (by the given name) or all scheduled tasks from the Cron class.

I was missing a feature to remove a task once it was scheduled. So I added some functions to handle my request. Editing the tasks is thread-safe: The queue can only be manipulatet when `tick` is not called.
