### PR TITLE
Fix warning: ignoring '#pragma warning '

### DIFF
--- a/libcron/include/libcron/CronSchedule.h
+++ b/libcron/include/libcron/CronSchedule.h
@@ -2,12 +2,12 @@
 
 #include "libcron/CronData.h"
 #include <chrono>
-#ifdef _WIN32
+#if defined(_WIN32) && defined(_MSC_VER)
 #pragma warning(push)
 #pragma warning(disable:4244)
 #endif
 #include <date/date.h>
-#ifdef _WIN32
+#if defined(_WIN32) && defined(_MSC_VER)
 #pragma warning(pop)
 #endif
 

--- a/libcron/include/libcron/CronSchedule.h
+++ b/libcron/include/libcron/CronSchedule.h
@@ -2,12 +2,12 @@
 
 #include "libcron/CronData.h"
 #include <chrono>
-#if defined(_WIN32) && defined(_MSC_VER)
+#if defined(_MSC_VER)
 #pragma warning(push)
 #pragma warning(disable:4244)
 #endif
 #include <date/date.h>
-#if defined(_WIN32) && defined(_MSC_VER)
+#if defined(_MSC_VER)
 #pragma warning(pop)
 #endif
 


### PR DESCRIPTION
The `#pragma warning` macro only works with MSVC compiler on Windows. On other compilers like MinGW GCC, some warnings will pop up. Adding a MSVC-specific macro to the condition will fix this.