### PR TITLE
Fix task may appear to be triggered more than 1 second late

### DIFF
--- a/libcron/src/CronSchedule.cpp
+++ b/libcron/src/CronSchedule.cpp
@@ -81,6 +81,14 @@ namespace libcron
             }
         }
 
+        // Discard fraction seconds in the calculated schedule time
+        //  that may leftover from the argument `from`, which in turn comes from `now()`.
+        // Fraction seconds will potentially make the task be triggered more than 1 second late
+        //  if the `tick()` within the same second is earlier than schedule time,
+        //  in that the task will not trigger until the next `tick()` next second.
+        // By discarding fraction seconds in the scheduled time,
+        //  the `tick()` within the same second will never be earlier than schedule time,
+        //  and the task will trigger in that `tick()`.
         curr -= curr.time_since_epoch() % seconds{1};
 
         return std::make_tuple(max_iterations > 0, curr);

--- a/libcron/src/CronSchedule.cpp
+++ b/libcron/src/CronSchedule.cpp
@@ -81,6 +81,8 @@ namespace libcron
             }
         }
 
+        curr -= curr.time_since_epoch() % seconds{1};
+
         return std::make_tuple(max_iterations > 0, curr);
     }
 }


### PR DESCRIPTION
The calculation of next trigger time do not discard fractional seconds. Depending on the exact timing of ticking, the task may appear to be triggered more than 1 second late, despite properly ticked every second.

Example: Suppose a task is scheduled to trigger at 00 second, but the calculated next trigger time is at 00.5 second, while `tick()` is happening at every .35 second. At 00.35 second a tick happened, but because 00.35 < 00.5 the task is not triggered. It will be triggered in the next tick that's at 01.35 second, which appeared to be late for 1.35 second (despite `get_delay()` will return 1.35 - 0.5 = 0.85 second in this case).

The source of the fractional seconds is from the `from` argument, where `now()`, a clock that usually have sub-second precision, is passed. If during the calculation, `date_changed` is never `true`, the variable `curr` will only be modified through `+=` and `-=` in the second half of the function, where the increments and/or decrements are all multiple of whole seconds.

This fix calculates the fractional second by modulo 1 second, then subtracted that from the calculated time. Since the trigger time is now scheduled at exact second, whenever tick happened within that second the task will be triggered. Doing floor by `std::duration_cast<>` is not good because it changes the `duration` type (because of different `ratio`), and therefore the the `time_point` type (because of different `duration`).
