### PR TITLE
Add default copy assignment operator to data classes

### DIFF
--- a/libcron/include/libcron/CronData.h
+++ b/libcron/include/libcron/CronData.h
@@ -21,6 +21,8 @@ namespace libcron
 
             CronData(const CronData&) = default;
 
+            CronData& operator=(const CronData&) = default;
+
             bool is_valid() const
             {
                 return valid;

--- a/libcron/include/libcron/CronSchedule.h
+++ b/libcron/include/libcron/CronSchedule.h
@@ -25,6 +25,8 @@ namespace libcron
 
             CronSchedule(const CronSchedule&) = default;
 
+            CronSchedule& operator=(const CronSchedule&) = default;
+
             std::tuple<bool, std::chrono::system_clock::time_point>
             calculate_from(const std::chrono::system_clock::time_point& from) const;
 


### PR DESCRIPTION
This simple patch adds default copy assignment operator to `CronData` and `CronSchedule` class to suppress the warning `definition of implicit copy assignment operator for 'CronData' is deprecated because it has a user-declared copy constructor`.